### PR TITLE
[BLIVE] 适配 Chrome 新版搭配 Media Foundation 解码稳定性问题

### DIFF
--- a/bilibiliLive/blivePlus.user.js
+++ b/bilibiliLive/blivePlus.user.js
@@ -2,7 +2,7 @@
 // @name        bilibili直播间工具
 // @namespace   indefined
 // @supportURL  https://github.com/indefined/UserScripts/issues
-// @version     0.5.48.1
+// @version     0.5.49.1
 // @author      indefined
 // @description 可配置 直播间切换勋章/头衔、礼物包裹替换为大图标、网页全屏自动隐藏礼物栏/全屏发送弹幕(仅限HTML5)、轮播显示链接(仅限HTML5)
 // @include     /^https?:\/\/live\.bilibili\.com\/(blanc\/)?\d/
@@ -538,7 +538,7 @@ body.fullscreen-fix #live-player div~div#gift-control-vm,
             && (helper.window.livePlayer||helper.window.top.livePlayer).getVideoEl()
             || helper.get('video');
             if (video && video.buffered.length) {
-                video.currentTime = video.buffered.end(0);
+                video.currentTime = video.buffered.end(0)-1;
             }
         },
     },


### PR DESCRIPTION
未来 Chrome 会随着 Windows 11 和新的硬件而采用 Media Foundation 作为预设编解码器，此更新为提前适配。
目前 MFS 可在 FLAGS 中启用。

以下为技术解释。
——————————
MFS的缓冲不该为0，不然容易出现数据不足（网络延迟等因素）而解码出错，导致画面卡顿甚至花屏。
【建议至少保留1秒缓冲区，这个得看主播的编码设定，高参压缩可能需要增大缓冲区。暂定1秒，目测稳定，需搭配更多硬件和网络条件的反馈来确定。】
【旧版DS解码只会造成瞬间卡顿，但不会花屏，因为会自动重新缓冲足以正确解码的数据量后才重新开始播放，但这会造成更高的延迟。采用MFS能获得更高的解码效能。】